### PR TITLE
Fixing a problem encountered with bash 3

### DIFF
--- a/lib/parallelize-run-jobs
+++ b/lib/parallelize-run-jobs
@@ -12,7 +12,11 @@ parallelizeRunJobs() {
     while [[ "${#parallelizeJobs[@]}" -gt 0 && "${#parallelizeJobPids[@]}" -lt "$parallelizeProcessMax" ]]; do
         # Shift off the first job.
         job="${parallelizeJobs[0]}"
-        parallelizeJobs=("${parallelizeJobs[@]:1}")
+
+        # This requires IFS to either contain a space or be unset. There's
+        # bug in bash prior to 4.0-rc1 that would convert the array into
+        # a single string.
+        IFS= parallelizeJobs=("${parallelizeJobs[@]:1}")
 
         # Start the job in a subshell so it is unable to affect the current
         # shell.


### PR DESCRIPTION
Sample test script:

    IFS=$'\n\t'
    a=(one two three)
    b=("${a[@]:1}")
    [[ "${b[0]}" == "two" ]]

When the script fails it is because either bash does not support arrays
(really old versions) or because `b` was set to `("two three")`.

The fix is to set `IFS` to contain a space or unset it.